### PR TITLE
Add note on local storage.

### DIFF
--- a/fundamentals/logging.md
+++ b/fundamentals/logging.md
@@ -30,6 +30,10 @@ alloy("log", {
 Note that you may execute this `log` command within your browser's JavaScript console to toggle logging at any time. This can be particularly useful when it's difficult to change code on your webpage or you don't want logging messages to be produced for all users of your website.
 {% endhint %}
 
+{% hint style="info" %}
+Note that the value of the `log` command or config gets set in local storage. If you want to toggle logging, you will need to pass the opposite value of the initial setting. For example, if logging was set to `true` and you would like to turn it off, you will need to set the `log` config to `false`; omitting the `log` config will not be enough to turn it off.
+{% endhint %}
+
 Additionally logging can be enabled by adding `alloy_log=true` as query parameter in the URL to enable logging to enabled it just on your browser.
 
 ```http


### PR DESCRIPTION
Mention that the log value gets set in local storage.

## Additional Details

That the log gets stored in local storage by default. So to undo a `log` setting, simply removing the `log` config won’t be enough. You’ll have to set this config to the opposite value

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ x ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ x ] I have read the **CONTRIBUTING** document.
