### PR TITLE
Added more detail and importance to event types

### DIFF
--- a/fundamentals/tracking-events.md
+++ b/fundamentals/tracking-events.md
@@ -23,9 +23,30 @@ alloy("event", {
 });
 ```
 
-## Starting a View
+{% hint style="warning" %}
+Be sure to understand how to track different types of events as outlined below. Failing to do so may result in a loss of functionality.
+{% endhint %}
 
-When a view has started, you will need to notify the SDK by setting `type` to `viewStart` within the `event` command. The definition of a view can depend on the context.
+## Event Types
+
+For each event, you may pass in a `type` property indicating the type of event that occurred as follows:
+
+```javascript
+alloy("event", {
+  "type": "somethingOccurred",
+  "data": {
+    "key":"value"
+  },
+});
+```
+
+While you may pass in arbitrary values for the `type` property, there are also important built-in `type` values you should leverage. Below, you will learn about these built-in event types and the corresponding functionality they provide.
+
+### Starting a View
+
+When a view has started, it is important to notify the SDK by setting `type` to `viewStart` within the `event` command. This will indicate, among other things, that Alloy should retrieve and render personalization content. Even if you are not using personalization currently, it will greatly simplify enabling personalization or other features later because you will not be required to modify on-page code. In addition, tracking views will be beneficial when viewing analytics reports after data has been collected.
+
+The definition of a view can depend on the context.
 
 * In a regular website, each webpage would typically be considered a unique view. In this case, an event of type `viewStart` should be executed as soon as possible at the top of the page.
 * In a single page application \(SPA\), a view is less defined. It typically means that the user has navigated within the application and most of the content has changed. For those familiar with the technical foundations of single page applications, this is typically when the application loads a new route. Whenever a user moves to a new view, however you choose to define a "view", the event of type `viewStart` should be executed.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Additional Details
https://jira.corp.adobe.com/browse/CORE-31431

We were noticing a few examples where alpha customers were tracking events but never using the `viewStart` event type. We thought it would be good to highlight the importance of tracking event types like `viewStart`. I've tried to do so in this PR without being overbearing.

I feel like we need more detail about why a user would ever want to pass in an arbitrary event type. For example, where would this information be surfaced? How does it benefit the user? I didn't have the answers, so I didn't provide any more detail than what I knew. @dancingcactus, could you help fill in this part?

@jfkhoury, in the ticket I know you asked for a change in the heading to something like "Important Built-In Event Types", but I couldn't figure out how to get it to fit right in the content flow. See if you're okay with what I've proposed here.

<!--- Provide any additional details that may be useful -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [X] I have read the **CONTRIBUTING** document.
