### PR TITLE
Updated examples to include imsOrgID

### DIFF
--- a/fundamentals/configuring-the-sdk.md
+++ b/fundamentals/configuring-the-sdk.md
@@ -13,7 +13,8 @@ Configuration for the SDK is done with the `configure` command. This should _alw
 
 ```javascript
 alloy("configure", {
-  "propertyId": "ebebf826-a01f-4458-8cec-ef61de241c93"
+  "propertyId": "ebebf826-a01f-4458-8cec-ef61de241c93",
+  "imsOrgId":"ADB3LETTERSANDNUMBERS@AdobeOrg"
 });
 ```
 

--- a/fundamentals/interacting-with-multiple-properties.md
+++ b/fundamentals/interacting-with-multiple-properties.md
@@ -35,7 +35,8 @@ Following the above example, you can now execute commands using each of the inst
 
 ```javascript
 mycustomname1("configure", {
-  "propertyId": "ebebf826-a01f-4458-8cec-ef61de241c93"
+  "propertyId": "ebebf826-a01f-4458-8cec-ef61de241c93",
+  "imsOrgId":"ADB3LETTERSANDNUMBERS@AdobeOrg"
 });
 
 mycustomname1("event", {
@@ -45,7 +46,8 @@ mycustomname1("event", {
 });
 
 mycustomname2("configure", {
-  "propertyId": "f46e981f-fd03-4bdd-a9d9-73ce4447f870"
+  "propertyId": "f46e981f-fd03-4bdd-a9d9-73ce4447f870",
+  "imsOrgId":"ADB3NUMBERSANDLETTERS@AdobeOrg"
 });
 
 mycustomname2("event", {

--- a/fundamentals/logging.md
+++ b/fundamentals/logging.md
@@ -14,6 +14,7 @@ The `configure` command allows you to enable logging. If you set the `log` optio
 ```javascript
 alloy("configure", {
   "propertyId": "ebebf826-a01f-4458-8cec-ef61de241c93",
+  "imsOrgId":"ADB3LETTERSANDNUMBERS@AdobeOrg",
   "log": true
 });
 ```

--- a/fundamentals/supporting-opt-in.md
+++ b/fundamentals/supporting-opt-in.md
@@ -25,6 +25,7 @@ To prevent the SDK from performing these tasks until the user opts in, pass `"op
 ```javascript
 alloy("configure", {
   "propertyID": "ebebf826-a01f-4458-8cec-ef61de241c93",
+  "imsOrgId":"ADB3LETTERSANDNUMBERS@AdobeOrg",
   "optInEnabled": true
 });
 ```


### PR DESCRIPTION
Updates the examples of configure to include imsOrgId



## Checklist:

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] I have read the **CONTRIBUTING** document.
