### PR TITLE
Added a note about proper instance names.

### DIFF
--- a/fundamentals/installing-the-sdk.md
+++ b/fundamentals/installing-the-sdk.md
@@ -35,6 +35,10 @@ The base code, by default, creates a global function named `alloy`. You will use
 
 With this change made, the global function would be named `mycustomname` instead of `alloy`.
 
+{% hint style="warning" %}
+To avoid potential problems, please use a name containing at least one character that is not a digit and that doesn't conflict with the name of a property already found on `window`.
+{% endhint %}
+
 This base code, in addition to creating a global function, also loads additional code contained within an external file \(`alloy.js`\) hosted on a server. By default, this code is loaded asynchronously to allow your webpage to be as performant as possible. This is the recommended implementation.
 
 ## Supporting Internet Explorer


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Additional Details
Under [strict mode](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode), setting window["123"], where the key is all digits, throws a "Failed to set an indexed property on 'Window'" error.
<!--- Provide any additional details that may be useful -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] I have read the **CONTRIBUTING** document.
